### PR TITLE
Add generic identity step

### DIFF
--- a/lib/git_wizard.rb
+++ b/lib/git_wizard.rb
@@ -7,8 +7,12 @@ require "git_wizard/version"
 require "git_wizard/store"
 require "git_wizard/step"
 require "git_wizard/base"
-require "git_wizard/controller"
 require "git_wizard/issue_verification_code"
+require "git_wizard/validators/email_format_validator"
+require "git_wizard/validators/policy_validator"
+require "git_wizard/steps/authenticate"
+require "git_wizard/steps/identity"
+require "git_wizard/controller"
 
 module GITWizard
 end

--- a/lib/git_wizard/controller.rb
+++ b/lib/git_wizard/controller.rb
@@ -1,5 +1,3 @@
-require_relative "steps/authenticate"
-
 module GITWizard
   module Controller
     extend ActiveSupport::Concern

--- a/lib/git_wizard/steps/identity.rb
+++ b/lib/git_wizard/steps/identity.rb
@@ -1,0 +1,47 @@
+module GITWizard
+  module Steps
+    class Identity < ::GITWizard::Step
+      include ::GITWizard::IssueVerificationCode
+
+      attribute :first_name
+      attribute :last_name
+      attribute :email
+      attribute :accepted_policy_id
+
+      validates :first_name, presence: true, length: { maximum: 256 }
+      validates :last_name, presence: true, length: { maximum: 256 }
+      validates :email, presence: true, email_format: true
+      validates :accepted_policy_id, policy: true
+
+      before_validation :sanitize_input
+
+      def self.contains_personal_details?
+        true
+      end
+
+      def export
+        super.tap do |data|
+          data["accepted_policy_id"] ||= latest_privacy_policy.id
+        end
+      end
+
+      def reviewable_answers
+        super.tap { |answers|
+          answers["name"] = "#{answers['first_name']} #{answers['last_name']}"
+        }.without(%w[first_name last_name accepted_policy_id])
+      end
+
+      def latest_privacy_policy
+        @latest_privacy_policy ||= GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_latest_privacy_policy
+      end
+
+    private
+
+      def sanitize_input
+        self.email = email.to_s.strip.presence
+        self.first_name = first_name.to_s.strip.presence
+        self.last_name = last_name.to_s.strip.presence
+      end
+    end
+  end
+end

--- a/lib/git_wizard/validators/email_format_validator.rb
+++ b/lib/git_wizard/validators/email_format_validator.rb
@@ -1,0 +1,30 @@
+class EmailFormatValidator < ActiveModel::EachValidator
+  EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME = %r{\A[^\s@]+@[^.\s]+\.[^\s]+\z}.freeze
+  MAXIMUM_LENGTH = 100 # As specified by the CRM
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    invalid_format = !is_an_email_uri?(value) || !is_fqdn?(value)
+
+    if invalid_format
+      record.errors.add(attribute, :invalid)
+    elsif too_long?(value)
+      record.errors.add(attribute, :too_long)
+    end
+  end
+
+private
+
+  def is_an_email_uri?(value)
+    value.to_s.match?(URI::MailTo::EMAIL_REGEXP)
+  end
+
+  def is_fqdn?(value)
+    value.to_s.match?(EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME)
+  end
+
+  def too_long?(value)
+    value.to_s.length > MAXIMUM_LENGTH
+  end
+end

--- a/lib/git_wizard/validators/policy_validator.rb
+++ b/lib/git_wizard/validators/policy_validator.rb
@@ -1,0 +1,13 @@
+class PolicyValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value.present?
+
+    begin
+      policy = GetIntoTeachingApiClient::PrivacyPoliciesApi.new.get_privacy_policy(value)
+    rescue GetIntoTeachingApiClient::ApiError => e
+      raise unless e.code == 400
+    end
+
+    record.errors.add(attribute, :invalid_policy) unless policy
+  end
+end

--- a/lib/git_wizard/version.rb
+++ b/lib/git_wizard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GITWizard
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/git_wizard/steps/identity_spec.rb
+++ b/spec/git_wizard/steps/identity_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+describe GITWizard::Steps::Identity, type: :model do
+  include_context "with wizard step"
+  include_context "sanitize fields", %i[email first_name last_name]
+
+  let(:latest_policy) { GetIntoTeachingApiClient::PrivacyPolicy.new(id: "abc-123", text: "Latest privacy policy") }
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+      receive(:get_latest_privacy_policy) { latest_policy }
+  end
+
+  it_behaves_like "a wizard step"
+
+  it { expect(described_class).to include(::GITWizard::IssueVerificationCode) }
+
+  it { is_expected.to be_contains_personal_details }
+
+  describe "attributes" do
+    it { is_expected.to respond_to :first_name }
+    it { is_expected.to respond_to :last_name }
+    it { is_expected.to respond_to :email }
+    it { is_expected.to respond_to :accepted_policy_id }
+  end
+
+  describe "first_name" do
+    it { is_expected.not_to allow_values(nil, "", "a" * 257).for :first_name }
+    it { is_expected.to allow_values("John").for :first_name }
+  end
+
+  describe "last_name" do
+    it { is_expected.not_to allow_values(nil, "", "a" * 257).for :last_name }
+    it { is_expected.to allow_values("John").for :last_name }
+  end
+
+  describe "email" do
+    it { is_expected.not_to allow_values(nil, "", "a@#{'a' * 101}.com", "some@thing").for :email }
+    it { is_expected.to allow_values("test@test.com", "test%.mctest@domain.co.uk").for :email }
+  end
+
+  describe "#accepted_policy_id" do
+    let(:invalid_id) { "invalid-id" }
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+        receive(:get_privacy_policy) { latest_policy.id }
+
+      bad_request_error = GetIntoTeachingApiClient::ApiError.new(code: 400)
+      allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+        receive(:get_privacy_policy).with(invalid_id).and_raise(bad_request_error)
+    end
+
+    it { is_expected.to allow_value(latest_policy.id).for :accepted_policy_id }
+    it { is_expected.not_to allow_value(invalid_id).for :accepted_policy_id }
+  end
+
+  describe "#latest_privacy_policy" do
+    subject { instance.latest_privacy_policy }
+
+    it { is_expected.to eq(latest_policy) }
+  end
+
+  describe "#reviewable_answers" do
+    subject { instance.reviewable_answers }
+
+    before do
+      instance.first_name = "John"
+      instance.last_name = "Doe"
+      instance.email = "john@doe.com"
+    end
+
+    it { is_expected.to eq({ "name" => "John Doe", "email" => "john@doe.com" }) }
+  end
+
+  describe "#export" do
+    let(:backingstore) do
+      {
+        "first_name" => "first",
+        "last_name" => "last",
+        "email" => "email",
+        "accepted_policy_id" => "456",
+      }
+    end
+
+    subject { instance.export }
+
+    it { is_expected.to include(backingstore) }
+
+    context "when a policy id has not been set" do
+      let(:backingstore) { {} }
+
+      it "defaults to the latest policy id" do
+        is_expected.to include("accepted_policy_id" => latest_policy.id)
+      end
+    end
+  end
+end

--- a/spec/git_wizard/validators/email_format_validator_spec.rb
+++ b/spec/git_wizard/validators/email_format_validator_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe EmailFormatValidator do
+  subject { instance.errors }
+
+  let(:test_model) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :email
+
+      validates :email, email_format: true
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "test")
+      end
+    end
+  end
+
+  before { instance.valid? }
+
+  context "with invalid addresses" do
+    %w[test.com test@@test.com test@test test@test.].each do |email|
+      let(:instance) { test_model.new(email: email) }
+
+      it "#{email} should not be valid" do
+        expect(subject).to be_added(:email, :invalid)
+      end
+    end
+
+    context "when over 100 characters" do
+      let(:instance) { test_model.new(email: "#{'a' * 100}@test.com") }
+
+      it "is not be valid" do
+        expect(subject).to be_added(:email, :too_long)
+      end
+    end
+  end
+
+  context "with valid addresses" do
+    %w[test@example.com testymctest@gmail.com test%.mctest@domain.co.uk]
+      .each do |email|
+      let(:instance) { test_model.new(email: email) }
+
+      it "#{email} should be valid" do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end

--- a/spec/git_wizard/validators/policy_validator_spec.rb
+++ b/spec/git_wizard/validators/policy_validator_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+class PolicyValidatable
+  include ActiveModel::Model
+
+  attr_accessor :policy_id
+
+  validates :policy_id, policy: true
+end
+
+RSpec.describe PolicyValidator, type: :validator do
+  subject { PolicyValidatable.new }
+
+  it "is valid when matches a policy" do
+    policy = GetIntoTeachingApiClient::PrivacyPolicy.new(id: "abc-123")
+
+    expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+      receive(:get_privacy_policy).with(policy.id).and_return(policy)
+
+    subject.policy_id = policy.id
+    expect(subject).to be_valid
+  end
+
+  it "is invalid when does not match a policy" do
+    bad_request_error = GetIntoTeachingApiClient::ApiError.new(code: 400)
+    expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+      receive(:get_privacy_policy).with("def-678").and_raise(bad_request_error)
+
+    subject.policy_id = "def-678"
+    expect(subject).to be_invalid
+  end
+
+  it "is valid when nil" do
+    expect_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).not_to \
+      receive(:get_privacy_policy)
+
+    subject.policy_id = nil
+    expect(subject).to be_valid
+  end
+end

--- a/spec/git_wizard_spec.rb
+++ b/spec/git_wizard_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe GITWizard do
   describe "VERSION" do
     subject { described_class::VERSION }
 
-    it { is_expected.to eql "2.0.0" }
+    it { is_expected.to eql "2.1.0" }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ require "rails-controller-testing"
 require "dummy/config/environment"
 require "shoulda/matchers"
 
+Dir["#{Dir.getwd}/spec/support/**/*.rb"].sort.each { |f| require f }
+
 require "spec_helper"
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/shared_examples/sanitize_input.rb
+++ b/spec/support/shared_examples/sanitize_input.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples "sanitize fields" do |fields|
+  fields.each do |field|
+    it "sanitizes input on the #{field} field" do
+      setter = "#{field}="
+      subject.send(setter, "   input  ")
+      subject.valid?
+      expect(subject.send(field)).to eq("input")
+      subject.send(setter, "   ")
+      subject.valid?
+      expect(subject.send(field)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
[Trello-3972](https://trello.com/c/kc0Bl99o/3972-make-a-generic-identifystep-model-in-wizard-to-share-logic-across-git-tta)

We currently have very similar first steps to all of our sign up journeys; asking for first name, last name, email and assigning the accepted privacy policy.

This pulls the common attributes and functionality from these steps into a generic `Identity` model that can be inherited from in all services/use cases. It should let us DRY up those implementations.

Corresponding PRs for clients:

https://github.com/DFE-Digital/get-teacher-training-adviser-service/pull/1206
https://github.com/DFE-Digital/get-into-teaching-app/pull/3041